### PR TITLE
[AIRAVATA-3008] Hide outer scroll bar in body

### DIFF
--- a/django_airavata/static/common/scss/main.scss
+++ b/django_airavata/static/common/scss/main.scss
@@ -6,6 +6,7 @@ body {
 body {
     color: #333;
     background-color: #f7f7f7;
+    overflow: hidden;
 }
 
 .c-header {


### PR DESCRIPTION
Minor CSS change to avoid showing 2 scroll bars in all views. 
Added _overflow: hidden_ to body tag
_max-width_ has been kept the same