### PR TITLE
Fix for notice management. AIravata-3120

### DIFF
--- a/django_airavata/static/common/js/components/GatewayNoticesContainer.vue
+++ b/django_airavata/static/common/js/components/GatewayNoticesContainer.vue
@@ -41,7 +41,7 @@
                   class="notification-title text-wrap"
                   :class="textColor(notice)"
                 >{{ notice.title }}</span>
-                <a
+                <a v-if="!notice.is_read"
                   class="fas fa-dot-circle"
                   data-toggle="tooltip"
                   data-placement="left"
@@ -93,9 +93,8 @@ export default {
   },
   computed: {
     unreadNotices() {
-      return this.notices.filter(n => !n.is_read);
+      return this.notices;
     }
   }
 };
 </script>
-


### PR DESCRIPTION
Fixing the notice management to show both read and unread notifications. Unread notifications have a button that user can use to mark them as read. Airavata-3120