### PR TITLE
Changes to GatewayResourceProfile

### DIFF
--- a/airavata/model/appcatalog/gatewayprofile/ttypes.py
+++ b/airavata/model/appcatalog/gatewayprofile/ttypes.py
@@ -322,6 +322,7 @@ class StoragePreference(object):
      - loginUserName
      - fileSystemRootLocation
      - resourceSpecificCredentialStoreToken
+     - userStorageQuota
     """
 
     thrift_spec = (
@@ -330,13 +331,15 @@ class StoragePreference(object):
         (2, TType.STRING, 'loginUserName', 'UTF8', None, ),  # 2
         (3, TType.STRING, 'fileSystemRootLocation', 'UTF8', None, ),  # 3
         (4, TType.STRING, 'resourceSpecificCredentialStoreToken', 'UTF8', None, ),  # 4
+        (5, TType.I64, 'userStorageQuota', None, None, ),  # 5
     )
 
-    def __init__(self, storageResourceId=None, loginUserName=None, fileSystemRootLocation=None, resourceSpecificCredentialStoreToken=None,):
+    def __init__(self, storageResourceId=None, loginUserName=None, fileSystemRootLocation=None, resourceSpecificCredentialStoreToken=None, userStorageQuota=None,):
         self.storageResourceId = storageResourceId
         self.loginUserName = loginUserName
         self.fileSystemRootLocation = fileSystemRootLocation
         self.resourceSpecificCredentialStoreToken = resourceSpecificCredentialStoreToken
+        self.userStorageQuota = userStorageQuota
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -367,6 +370,11 @@ class StoragePreference(object):
                     self.resourceSpecificCredentialStoreToken = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
+            elif fid == 5:
+                if ftype == TType.I64:
+                    self.userStorageQuota = iprot.readI64()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -392,6 +400,10 @@ class StoragePreference(object):
         if self.resourceSpecificCredentialStoreToken is not None:
             oprot.writeFieldBegin('resourceSpecificCredentialStoreToken', TType.STRING, 4)
             oprot.writeString(self.resourceSpecificCredentialStoreToken.encode('utf-8') if sys.version_info[0] == 2 else self.resourceSpecificCredentialStoreToken)
+            oprot.writeFieldEnd()
+        if self.userStorageQuota is not None:
+            oprot.writeFieldBegin('userStorageQuota', TType.I64, 5)
+            oprot.writeI64(self.userStorageQuota)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()

--- a/django_airavata/apps/admin/static/django_airavata_admin/src/components/gatewayprofile/StoragePreferenceEditor.vue
+++ b/django_airavata/apps/admin/static/django_airavata_admin/src/components/gatewayprofile/StoragePreferenceEditor.vue
@@ -3,6 +3,9 @@
     <b-form-group label="Login username" label-for="login-username">
       <b-form-input id="login-username" v-model="data.loginUserName" type="text" />
     </b-form-group>
+    <b-form-group label="User Storage Quota (in KB)" label-for="user-storage-quota">
+      <b-form-input id="user-storage-quota" v-model="data.userStorageQuota" type="number" v-on:keypress = "handleTypedInput" v-on:paste= "handlePastedInput" />
+    </b-form-group>
     <b-form-group label="File System Root Location" label-for="filesystem-root-location">
       <b-form-input id="filesystem-root-location" v-model="data.fileSystemRootLocation" type="text" />
     </b-form-group>
@@ -38,6 +41,21 @@ export default {
       required: true
     }
   },
+  methods: {
+    handleTypedInput() {
+      const evt = window.event;
+      var charCode = evt.which || evt.keyCode;
+      if ((charCode >= 48 && charCode <= 57) || charCode === 46)
+        return true;
+      evt.preventDefault();
+    },
+    handlePastedInput() {
+      const evt = window.event;
+      var num = Number(evt.clipboardData.getData('text/plain'));
+      if (num >= 0)
+        return true;
+      evt.preventDefault();
+    },
+  }
 };
 </script>
-

--- a/django_airavata/apps/admin/static/django_airavata_admin/src/components/gatewayprofile/StoragePreferenceEditor.vue
+++ b/django_airavata/apps/admin/static/django_airavata_admin/src/components/gatewayprofile/StoragePreferenceEditor.vue
@@ -42,19 +42,17 @@ export default {
     }
   },
   methods: {
-    handleTypedInput() {
-      const evt = window.event;
-      var charCode = evt.which || evt.keyCode;
+    handleTypedInput(event) {
+      const charCode = event.which || event.keyCode;
       if ((charCode >= 48 && charCode <= 57) || charCode === 46)
         return true;
-      evt.preventDefault();
+      event.preventDefault();
     },
-    handlePastedInput() {
-      const evt = window.event;
-      var num = Number(evt.clipboardData.getData('text/plain'));
+    handlePastedInput(event) {
+      const num = Number(event.clipboardData.getData('text/plain'));
       if (num >= 0)
         return true;
-      evt.preventDefault();
+      event.preventDefault();
     },
   }
 };

--- a/django_airavata/apps/admin/static/django_airavata_admin/src/components/gatewayprofile/StoragePreferenceList.vue
+++ b/django_airavata/apps/admin/static/django_airavata_admin/src/components/gatewayprofile/StoragePreferenceList.vue
@@ -80,7 +80,8 @@ export default {
       showNewItemEditor: false,
       newStoragePreference: null,
       storageResourceNames: null,
-      credentials: null
+      credentials: null,
+      defaultUserStorageQuota: "N/A"
     };
   },
   computed: {
@@ -100,6 +101,11 @@ export default {
           label: "SSH Credential",
           key: "resourceSpecificCredentialStoreToken",
           formatter: value => this.getCredentialName(value)
+        },
+        {
+          label: "User Storage Quota (In KB)",
+          key: "userStorageQuota",
+          formatter: value => this.getUserStorageQuota(value)
         },
         {
           label: "File System Location",
@@ -176,6 +182,13 @@ export default {
         }
       }
       return "...";
+    },
+    getUserStorageQuota(token) {
+      if(token === null || token === 0) {
+        return this.defaultUserStorageQuota;
+      } else {
+        return token;
+      }
     },
     updatedStoragePreference(newValue) {
       this.$emit("updated", newValue);

--- a/django_airavata/apps/admin/static/django_airavata_admin/src/components/gatewayprofile/StoragePreferenceList.vue
+++ b/django_airavata/apps/admin/static/django_airavata_admin/src/components/gatewayprofile/StoragePreferenceList.vue
@@ -183,12 +183,11 @@ export default {
       }
       return "...";
     },
-    getUserStorageQuota(token) {
-      if(token === null || token === 0) {
+    getUserStorageQuota(value) {
+      if(value === null || value === 0)
         return this.defaultUserStorageQuota;
-      } else {
-        return token;
-      }
+      else
+        return value;
     },
     updatedStoragePreference(newValue) {
       this.$emit("updated", newValue);

--- a/django_airavata/apps/api/static/django_airavata_api/js/models/StoragePreference.js
+++ b/django_airavata/apps/api/static/django_airavata_api/js/models/StoragePreference.js
@@ -3,6 +3,7 @@ import BaseModel from "./BaseModel";
 const FIELDS = [
   "storageResourceId",
   "loginUserName",
+  "userStorageQuota",
   "fileSystemRootLocation",
   "resourceSpecificCredentialStoreToken"
 ];


### PR DESCRIPTION
This is the first cut as part of EPIC: https://issues.apache.org/jira/browse/AIRAVATA-3315. By adding a new entry called UserStoragePreference, an admin user can configure storage quotas for the users in the Gateway.

0 is the default value for the UserStorageQuota entry, and the frontend, instead of displaying the value 0, displays "N/A" letting know the client that there are no storage restrictions in the Gateway.

It doesn't make any sense for the storage quota entry to have a negative number. So the client-side code has validations to make sure any typed or pasted value in the UserStorageQuota entry does not store any negative values.