### PR TITLE
fixing typo

### DIFF
--- a/django_airavata/apps/admin/static/django_airavata_admin/src/components/notices/NoticesManagementContainer.vue
+++ b/django_airavata/apps/admin/static/django_airavata_admin/src/components/notices/NoticesManagementContainer.vue
@@ -176,7 +176,7 @@ export default {
       this.updatedNotice = new models.Notification(),
       this.updatedNotice = row.item;
       row.toggleDetails();
-      this.showingDetails[row.item.notifiticationId] = !this
+      this.showingDetails[row.item.notificationId] = !this
         .showingDetails[row.item.notificationId];
     }
   }


### PR DESCRIPTION
Changed the variable name since there was a typo.