### PR TITLE
Upgraded grpcio and grpcio-tools to resolve the build issue on Apple Silicon Chips

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,9 @@ papermill==1.0.1
 # gRPC libs
 google-api-python-client==1.12.8
 grpcio-tools==1.48.2 ; python_version < "3.7"
-grpcio-tools==1.51.1 ; python_version >= "3.7"
+grpcio-tools==1.57.0 ; python_version >= "3.7"
 grpcio==1.48.2 ; python_version < "3.7"
-grpcio==1.51.1 ; python_version >= "3.7"
+grpcio==1.57.0 ; python_version >= "3.7"
 
 airavata-django-portal-sdk==1.8.4
 airavata-python-sdk==1.1.6


### PR DESCRIPTION
Upgraded versions of the mentioned packages will fix the following issue,

> /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/Headers -arch arm64 -arch x86_64 -Werror=implicit-function-declaration -Wno-error=unreachable-code -I/opt/homebrew/opt/protobuf@3/include -DHAVE_PTHREAD=1 -I. -Igrpc_root -Igrpc_root/include -Ithird_party/protobuf/src -I/Users/lahiru/Projects/CIRC/airavata-django-portal/venv-test/include -I/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/Headers -c third_party/protobuf/src/google/protobuf/wire_format.cc -o build/temp.macosx-10.10-universal2-cpython-39/third_party/protobuf/src/google/protobuf/wire_format.o -std=c++14 -fno-wrapv -frtti
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for grpcio-tools
  Running setup.py clean for grpcio-tools
Failed to build grpcio-tools
ERROR: Could not build wheels for grpcio-tools, which is required to install pyproject.toml-based projects
