### PR TITLE
Node.js Version Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # node image is based on Debian and includes necessary build tools
-FROM node:lts as build-stage
+FROM node:19.9.0 as build-stage
 
 # build api javascript
 # api must come first, then common, since the others depend on these

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ The Airavata Django Portal works with Python versions 3.6 - 3.10. You'll need
 one of these versions installed locally.
 
 You'll also need Node.js and yarn to build the JavaScript frontend code. Please
-install
-[the most recent LTS version of Node.js](https://nodejs.org/en/download/). You
+install Node.js version 19. You
 can also use [nvm](https://github.com/nvm-sh/nvm) to manage the Node.js install.
 If you have nvm installed you can run `nvm install && nvm use` before running
 any yarn commands. See


### PR DESCRIPTION
The README suggests installing the latest version of Node.js. This advice was based on the situation before version '20.12.0' was released. Version 19 is required.