### PR TITLE
fix integrity error in cms fixture

### DIFF
--- a/django_airavata/wagtailapps/base/fixtures/new_default_theme.json
+++ b/django_airavata/wagtailapps/base/fixtures/new_default_theme.json
@@ -3455,7 +3455,7 @@
     "model": "taggit.tag",
     "pk": 14,
     "fields": {
-        "name": "logo",
+        "name": "logo_1",
         "slug": "logo_1"
     }
 },


### PR DESCRIPTION
#### While running the following command:  
```sh
python manage.py load_cms_data new_default_theme
```
#### the process failed with the following error:

django.db.utils.IntegrityError: Problem installing fixture: Could not load taggit.Tag(pk=14): (1062, "Duplicate entry 'logo' for key 'taggit_tag.name'")

This happened because the fixture tried inserting a tag with a duplicate name, violating the unique constraint in the taggit_tag table.

#### Fix:
Renamed the duplicate tag name
This fix removes a blocking issue from the project setup process

@lahirujayathilake 