### PR TITLE
feat: add sandboxed HTML output rendering

### DIFF
--- a/django_airavata/apps/admin/static/django_airavata_admin/src/components/applications/ApplicationOutputFieldEditor.vue
+++ b/django_airavata/apps/admin/static/django_airavata_admin/src/components/applications/ApplicationOutputFieldEditor.vue
@@ -85,7 +85,14 @@
         :disabled="readonly"
       />
     </b-form-group>
-    <b-button size="sm" @click="setPlainText">Plain Text</b-button>
+    <div>
+      <b-button size="sm" @click="setPlainText" :disabled="readonly"
+        >Plain Text</b-button
+      >
+      <b-button size="sm" class="ml-2" @click="setHtml" :disabled="readonly"
+        >HTML</b-button
+      >
+    </div>
   </b-card>
 </template>
 
@@ -138,11 +145,29 @@ export default {
     deleteApplicationOutput() {
       this.$emit("delete");
     },
+    cloneMetadata() {
+      return this.data.metaData
+        ? JSON.parse(JSON.stringify(this.data.metaData))
+        : {};
+    },
     setPlainText() {
-      const metadata = this.data.metaData || {};
+      const metadata = this.cloneMetadata();
       metadata["file-metadata"] = { "mime-type": "text/plain" };
-      // Clone so that JSONEditor updates with new value
-      this.data.metaData = JSON.parse(JSON.stringify(metadata));
+      this.data.metaData = metadata;
+    },
+    setHtml() {
+      const metadata = this.cloneMetadata();
+      metadata["file-metadata"] = { "mime-type": "text/html" };
+      const outputViewProviders = Array.isArray(
+        metadata["output-view-providers"]
+      )
+        ? metadata["output-view-providers"].slice()
+        : [];
+      if (!outputViewProviders.includes("html-file")) {
+        outputViewProviders.push("html-file");
+      }
+      metadata["output-view-providers"] = outputViewProviders;
+      this.data.metaData = metadata;
     },
   },
   mounted() {

--- a/django_airavata/apps/admin/static/django_airavata_admin/src/components/applications/ApplicationOutputFieldEditor.vue
+++ b/django_airavata/apps/admin/static/django_airavata_admin/src/components/applications/ApplicationOutputFieldEditor.vue
@@ -153,6 +153,16 @@ export default {
     setPlainText() {
       const metadata = this.cloneMetadata();
       metadata["file-metadata"] = { "mime-type": "text/plain" };
+      if (Array.isArray(metadata["output-view-providers"])) {
+        const outputViewProviders = metadata["output-view-providers"].filter(
+          (providerId) => providerId !== "html-file"
+        );
+        if (outputViewProviders.length > 0) {
+          metadata["output-view-providers"] = outputViewProviders;
+        } else {
+          delete metadata["output-view-providers"];
+        }
+      }
       this.data.metaData = metadata;
     },
     setHtml() {

--- a/django_airavata/apps/admin/static/django_airavata_admin/tests/unit/components/applications/ApplicationOutputFieldEditor.spec.js
+++ b/django_airavata/apps/admin/static/django_airavata_admin/tests/unit/components/applications/ApplicationOutputFieldEditor.spec.js
@@ -1,0 +1,60 @@
+import { shallowMount } from "@vue/test-utils";
+import { models } from "django-airavata-api";
+import ApplicationOutputFieldEditor from "@/components/applications/ApplicationOutputFieldEditor.vue";
+
+function factory(metaData = {}) {
+  const output = new models.OutputDataObjectType({
+    name: "Report",
+    metaData,
+  });
+  return shallowMount(ApplicationOutputFieldEditor, {
+    propsData: {
+      value: output,
+    },
+    stubs: [
+      "b-button",
+      "b-card",
+      "b-form-group",
+      "b-form-input",
+      "b-form-radio-group",
+      "b-form-select",
+      "b-link",
+      "json-editor",
+    ],
+  });
+}
+
+describe("ApplicationOutputFieldEditor", () => {
+  test("setHtml configures HTML metadata and preserves existing providers", () => {
+    const wrapper = factory({
+      custom: {
+        keep: true,
+      },
+      "output-view-providers": ["existing-provider"],
+    });
+
+    wrapper.vm.setHtml();
+
+    expect(wrapper.vm.data.metaData).toEqual({
+      custom: {
+        keep: true,
+      },
+      "file-metadata": {
+        "mime-type": "text/html",
+      },
+      "output-view-providers": ["existing-provider", "html-file"],
+    });
+  });
+
+  test("setHtml does not duplicate html-file provider", () => {
+    const wrapper = factory({
+      "output-view-providers": ["html-file"],
+    });
+
+    wrapper.vm.setHtml();
+
+    expect(wrapper.vm.data.metaData["output-view-providers"]).toEqual([
+      "html-file",
+    ]);
+  });
+});

--- a/django_airavata/apps/admin/static/django_airavata_admin/tests/unit/components/applications/ApplicationOutputFieldEditor.spec.js
+++ b/django_airavata/apps/admin/static/django_airavata_admin/tests/unit/components/applications/ApplicationOutputFieldEditor.spec.js
@@ -57,4 +57,41 @@ describe("ApplicationOutputFieldEditor", () => {
       "html-file",
     ]);
   });
+
+  test("setPlainText removes html-file provider and preserves other providers", () => {
+    const wrapper = factory({
+      custom: {
+        keep: true,
+      },
+      "file-metadata": {
+        "mime-type": "text/html",
+      },
+      "output-view-providers": ["existing-provider", "html-file"],
+    });
+
+    wrapper.vm.setPlainText();
+
+    expect(wrapper.vm.data.metaData).toEqual({
+      custom: {
+        keep: true,
+      },
+      "file-metadata": {
+        "mime-type": "text/plain",
+      },
+      "output-view-providers": ["existing-provider"],
+    });
+  });
+
+  test("setPlainText removes output-view-providers when html-file is the only provider", () => {
+    const wrapper = factory({});
+
+    wrapper.vm.setHtml();
+    wrapper.vm.setPlainText();
+
+    expect(wrapper.vm.data.metaData).toEqual({
+      "file-metadata": {
+        "mime-type": "text/plain",
+      },
+    });
+  });
 });

--- a/django_airavata/apps/api/output_views.py
+++ b/django_airavata/apps/api/output_views.py
@@ -4,12 +4,14 @@ import json
 import logging
 import os
 from functools import partial
+from urllib.parse import urlencode
 
 import nbformat
 import papermill as pm
 from airavata.model.application.io.ttypes import DataType
 from airavata_django_portal_sdk import user_storage
 from django.conf import settings
+from django.urls import reverse
 from nbconvert import HTMLExporter
 
 logger = logging.getLogger(__name__)
@@ -34,6 +36,42 @@ class DefaultViewProvider:
             **kwargs):
         return {
         }
+
+
+class HtmlFileViewProvider:
+    display_type = 'html-iframe'
+    name = "HTML File"
+    mime_type = "text/html"
+
+    def generate_data(
+            self,
+            request,
+            experiment_output,
+            experiment,
+            output_file=None,
+            **kwargs):
+        data_product_uri = self._get_first_data_product_uri(experiment_output)
+        if data_product_uri is None:
+            return {
+                'url': None,
+            }
+        query_params = urlencode({
+            'data-product-uri': data_product_uri,
+            'mime-type': self.mime_type,
+        })
+        return {
+            'url': request.build_absolute_uri(
+                f"{reverse('airavata_django_portal_sdk:download')}?{query_params}")
+        }
+
+    def _get_first_data_product_uri(self, experiment_output):
+        value = getattr(experiment_output, 'value', None)
+        if not value:
+            return None
+        data_product_uri = value.split(",", 1)[0].strip()
+        if data_product_uri.startswith("airavata-dp"):
+            return data_product_uri
+        return None
 
 
 class ParameterizedNotebookViewProvider:
@@ -71,7 +109,8 @@ class ParameterizedNotebookViewProvider:
 
 
 DEFAULT_VIEW_PROVIDERS = {
-    'default': DefaultViewProvider()
+    'default': DefaultViewProvider(),
+    'html-file': HtmlFileViewProvider(),
 }
 
 

--- a/django_airavata/apps/api/tests/test_output_views.py
+++ b/django_airavata/apps/api/tests/test_output_views.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+
+from django_airavata import middleware
+from django_airavata.apps.api import output_views
+
+
+class HtmlFileViewProviderTests(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_html_file_provider_is_registered_as_default_provider(self):
+        self.assertIn("html-file", output_views.DEFAULT_VIEW_PROVIDERS)
+        self.assertEqual(
+            "html-iframe",
+            output_views.DEFAULT_VIEW_PROVIDERS["html-file"].display_type)
+
+    def test_html_file_provider_returns_html_download_url(self):
+        request = self.factory.get("/")
+        experiment_output = SimpleNamespace(
+            value="airavata-dp://test-gateway/html-report")
+
+        view_data = output_views.DEFAULT_VIEW_PROVIDERS[
+            "html-file"].generate_data(
+                request,
+                experiment_output,
+                experiment=SimpleNamespace())
+
+        parsed_url = urlparse(view_data["url"])
+        query_params = parse_qs(parsed_url.query)
+        self.assertEqual("/sdk/download/", parsed_url.path)
+        self.assertEqual(
+            ["airavata-dp://test-gateway/html-report"],
+            query_params["data-product-uri"])
+        self.assertEqual(["text/html"], query_params["mime-type"])
+
+
+class HtmlOutputFrameOptionsMiddlewareTests(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _response_with_deny_frame_options(self, request):
+        response = HttpResponse()
+        response["X-Frame-Options"] = "DENY"
+        return response
+
+    def test_html_download_file_responses_can_be_framed_same_origin(self):
+        request = self.factory.get(
+            "/sdk/download-file/",
+            {"mime-type": "text/html"})
+
+        response = middleware.HtmlOutputFrameOptionsMiddleware(
+            self._response_with_deny_frame_options)(request)
+
+        self.assertEqual("SAMEORIGIN", response["X-Frame-Options"])
+        self.assertEqual("sandbox", response["Content-Security-Policy"])
+
+    def test_non_html_download_file_responses_keep_existing_frame_options(self):
+        request = self.factory.get(
+            "/sdk/download-file/",
+            {"mime-type": "text/plain"})
+
+        response = middleware.HtmlOutputFrameOptionsMiddleware(
+            self._response_with_deny_frame_options)(request)
+
+        self.assertEqual("DENY", response["X-Frame-Options"])
+        self.assertNotIn("Content-Security-Policy", response)
+
+    def test_html_output_frame_options_middleware_is_installed(self):
+        self.assertIn(
+            "django_airavata.middleware.HtmlOutputFrameOptionsMiddleware",
+            settings.MIDDLEWARE)

--- a/django_airavata/apps/auth/tests/test_middleware.py
+++ b/django_airavata/apps/auth/tests/test_middleware.py
@@ -1,5 +1,5 @@
 
-from unittest.mock import MagicMock, sentinel
+from unittest.mock import MagicMock, patch, sentinel
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
@@ -7,6 +7,7 @@ from django.http import HttpResponseRedirect
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
+from django_airavata import middleware as airavata_middleware
 from django_airavata.apps.auth import models
 from django_airavata.apps.auth.middleware import (
     user_profile_completeness_check
@@ -121,3 +122,28 @@ class UserProfileCompletenessCheckTestCase(TestCase):
         self.assertTrue(request.user.is_authenticated)
         self.assertFalse(self.user_profile.is_complete)
         self._middleware_passes_through(request)
+
+
+class AiravataClientMiddlewareTestCase(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_uses_client_from_pool_connection_context(self):
+        request = self.factory.get(reverse('django_airavata_workspace:dashboard'))
+        pool = MagicMock()
+        pool.connection.return_value.__enter__.return_value = sentinel.airavata_client
+
+        def get_response(request):
+            self.assertIs(request.airavata_client, sentinel.airavata_client)
+            return sentinel.response
+
+        with patch.object(
+                airavata_middleware.utils,
+                "airavata_api_client_pool",
+                pool):
+            response = airavata_middleware.AiravataClientMiddleware(
+                get_response)(request)
+
+        self.assertIs(response, sentinel.response)
+        pool.connection.assert_called_once_with()

--- a/django_airavata/apps/workspace/static/django_airavata_workspace/js/components/experiment/output-displays/HtmlIframeOutputDisplay.vue
+++ b/django_airavata/apps/workspace/static/django_airavata_workspace/js/components/experiment/output-displays/HtmlIframeOutputDisplay.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <iframe
+      v-if="url"
+      :src="url"
+      class="html-output-frame"
+      sandbox
+      title="HTML output"
+    />
+    <div v-else class="text-muted">HTML output is not available.</div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "html-iframe-output-display",
+  props: {
+    viewData: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    url() {
+      return this.viewData && this.viewData.url ? this.viewData.url : null;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.html-output-frame {
+  display: block;
+  width: 100%;
+  min-height: 640px;
+  border: 1px solid var(--gray);
+  border-radius: 3px;
+}
+</style>

--- a/django_airavata/apps/workspace/static/django_airavata_workspace/js/components/experiment/output-displays/OutputDisplayContainer.vue
+++ b/django_airavata/apps/workspace/static/django_airavata_workspace/js/components/experiment/output-displays/OutputDisplayContainer.vue
@@ -54,6 +54,7 @@
 import { models } from "django-airavata-api";
 import { components } from "django-airavata-common-ui";
 import DefaultOutputDisplay from "./DefaultOutputDisplay";
+import HtmlIframeOutputDisplay from "./HtmlIframeOutputDisplay";
 import HtmlOutputDisplay from "./HtmlOutputDisplay";
 import ImageOutputDisplay from "./ImageOutputDisplay";
 import LinkOutputDisplay from "./LinkOutputDisplay";
@@ -74,6 +75,7 @@ export default {
   components: {
     "data-product-viewer": components.DataProductViewer,
     DefaultOutputDisplay,
+    HtmlIframeOutputDisplay,
     HtmlOutputDisplay,
     ImageOutputDisplay,
     LinkOutputDisplay,
@@ -151,6 +153,10 @@ export default {
         },
         html: {
           component: "html-output-display",
+          url: "/api/html-output/",
+        },
+        "html-iframe": {
+          component: "html-iframe-output-display",
           url: "/api/html-output/",
         },
         image: {

--- a/django_airavata/apps/workspace/static/django_airavata_workspace/tests/unit/components/experiment/output-displays/HtmlIframeOutputDisplay.spec.js
+++ b/django_airavata/apps/workspace/static/django_airavata_workspace/tests/unit/components/experiment/output-displays/HtmlIframeOutputDisplay.spec.js
@@ -1,0 +1,32 @@
+import { shallowMount } from "@vue/test-utils";
+import HtmlIframeOutputDisplay from "@/components/experiment/output-displays/HtmlIframeOutputDisplay.vue";
+
+describe("HtmlIframeOutputDisplay", () => {
+  test("renders sandboxed iframe for HTML output URL", () => {
+    const wrapper = shallowMount(HtmlIframeOutputDisplay, {
+      propsData: {
+        viewData: {
+          url: "http://testserver/sdk/download/?data-product-uri=abc&mime-type=text%2Fhtml",
+        },
+      },
+    });
+
+    const iframe = wrapper.find("iframe");
+    expect(iframe.exists()).toBe(true);
+    expect(iframe.attributes("src")).toBe(
+      "http://testserver/sdk/download/?data-product-uri=abc&mime-type=text%2Fhtml"
+    );
+    expect(iframe.attributes("sandbox")).toBe("");
+  });
+
+  test("renders unavailable message when no URL is provided", () => {
+    const wrapper = shallowMount(HtmlIframeOutputDisplay, {
+      propsData: {
+        viewData: {},
+      },
+    });
+
+    expect(wrapper.find("iframe").exists()).toBe(false);
+    expect(wrapper.text()).toContain("HTML output is not available.");
+  });
+});

--- a/django_airavata/middleware.py
+++ b/django_airavata/middleware.py
@@ -2,6 +2,7 @@
 import logging
 
 import thrift
+import thrift.transport.TTransport
 from django.shortcuts import render
 
 from . import utils
@@ -9,21 +10,19 @@ from . import utils
 logger = logging.getLogger(__name__)
 
 
-# TODO: use the pooled clients in the airavata-python-sdk directly instead of
-# these request attributes
 class AiravataClientMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        request.airavata_client = utils.airavata_api_client_pool
-        response = self.get_response(request)
+        with utils.airavata_api_client_pool.connection() as airavata_client:
+            request.airavata_client = airavata_client
+            response = self.get_response(request)
 
         return response
 
     def process_exception(self, request, exception):
-        if isinstance(exception,
-                      thrift.transport.TTransport.TTransportException):
+        if isinstance(exception, thrift.transport.TTransport.TTransportException):
             return render(
                 request,
                 'django_airavata/error_page.html',

--- a/django_airavata/middleware.py
+++ b/django_airavata/middleware.py
@@ -10,6 +10,41 @@ from . import utils
 logger = logging.getLogger(__name__)
 
 
+class HtmlOutputFrameOptionsMiddleware:
+    """Apply browser protections for HTML output downloads."""
+
+    CSP_HEADER = "Content-Security-Policy"
+    HTML_OUTPUT_DOWNLOAD_PATHS = {
+        "/sdk/download/",
+        "/sdk/download-file/",
+    }
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        mime_type = request.GET.get("mime-type", "").split(";", 1)[0].strip().lower()
+        if (request.path in self.HTML_OUTPUT_DOWNLOAD_PATHS and
+                mime_type == "text/html"):
+            response["X-Frame-Options"] = "SAMEORIGIN"
+            response[self.CSP_HEADER] = self._with_strict_sandbox_csp(
+                response.get(self.CSP_HEADER, ""))
+        return response
+
+    def _with_strict_sandbox_csp(self, csp):
+        directives = []
+        for directive in csp.split(";"):
+            directive = directive.strip()
+            if not directive:
+                continue
+            directive_name = directive.split(None, 1)[0].lower()
+            if directive_name != "sandbox":
+                directives.append(directive)
+        directives.append("sandbox")
+        return "; ".join(directives)
+
+
 class AiravataClientMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response

--- a/django_airavata/settings.py
+++ b/django_airavata/settings.py
@@ -93,6 +93,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django_airavata.middleware.HtmlOutputFrameOptionsMiddleware',
     'django_airavata.apps.auth.middleware.authz_token_middleware',
     'django_airavata.middleware.AiravataClientMiddleware',
     'django_airavata.middleware.profile_service_client',


### PR DESCRIPTION
## Summary
- add an HTML output view provider for text/html outputs
- render HTML outputs in a sandboxed iframe in the workspace
- add admin output metadata presets for Plain Text and HTML
- add CSP sandbox handling for downloaded HTML output responses

## Validation
- tested on dev.amos-gateway.org with a fake HTML output result
- unit tests added for output provider, middleware behavior, admin metadata preset behavior, and workspace HTML display

## User Flow

To enable HTML rendering for an application output:

1. Open the application interface in the Django Portal admin.
2. Edit the output field that should render as HTML.
3. Click the `HTML` preset button.
4. Save the application interface.

This writes the output metadata as `text/html` and adds the `html-file` output view provider.

For plain text outputs, click the `Plain Text` preset button. This sets the output MIME type to `text/plain` and
removes the `html-file` provider if it was previously selected.

After an experiment finishes, users can open the experiment result page in the workspace. If the output has generated
data and is configured with the `html-file` provider, the output display menu will show both `Default` and `HTML
File`. Selecting `HTML File` renders the result in a sandboxed iframe.

## Notes
- This PR targets the legacy standalone Airavata Django Portal currently used by the AMOS dev deployment.

## Screenshot
### Before PR:
- Admin setting page:
<img width="915" height="599" alt="image" src="https://github.com/user-attachments/assets/e67c8399-9719-45c1-8970-f4700899bdbf" />

- Experiments output page:
<img width="914" height="391" alt="image" src="https://github.com/user-attachments/assets/bfff6ccf-e590-4d1e-8174-ae5f9863b05e" />

### After PR:
- Admin setting page:
<img width="925" height="601" alt="image" src="https://github.com/user-attachments/assets/d574f920-b695-4318-a14c-7e0738e26774" />

- Experiments output page:
<img width="963" height="412" alt="image" src="https://github.com/user-attachments/assets/b369f935-8cda-4474-a82f-83f18578f691" />
<img width="933" height="645" alt="image" src="https://github.com/user-attachments/assets/63c4d7ae-1367-45e1-9e73-0abf72aa8c31" />